### PR TITLE
Limited availability for region 'sfo1' - changed default region from 'sfo1' to 'sfo2'

### DIFF
--- a/R/do_options.R
+++ b/R/do_options.R
@@ -73,7 +73,7 @@ do_options <- function(size = NULL, image = NULL, region = NULL, ssh_keys = NULL
   cat("Default options for spinning up a new droplet:", "\n")
   cat("[size]:     ", getOption("do_size", "not set (Defaults to: s-1vcpu-1gb)"), "\n")
   cat("[image]:    ", getOption("do_image", "not set (Defaults to: ubuntu-18-04-x64)"), "\n")
-  cat("[region]:   ", getOption("do_region", "not set (Defaults to: sfo1)"), "\n")
+  cat("[region]:   ", getOption("do_region", "not set (Defaults to: sfo2)"), "\n")
   cat("[ssh keys]: ", getOption("do_ssh_keys"), "\n")
   cat("[private networking]", getOption("do_private_networking"), "\n")
   cat("[backups]:  ", getOption("do_backups"), "\n")

--- a/R/docklet.R
+++ b/R/docklet.R
@@ -57,7 +57,7 @@
 #' IP address can most likely be found like \code{d$networks$v4[[1]]$ip_address}
 #' and the port is the port you set in the function call.
 #' @template dropid
-#' 
+#'
 #' @examples
 #' \dontrun{
 #' d <- docklet_create()
@@ -94,7 +94,7 @@
 #' ## following pattern user1/user1 ... through 100
 #' d <- docklet_create()
 #' d <- droplet(d$id)
-#' d %>% docklet_rstudio(user = "foo", password = "bar") %>% 
+#' d %>% docklet_rstudio(user = "foo", password = "bar") %>%
 #'  docklet_rstudio_addusers(user = "foo", password = "bar")
 #'
 #' # Spin up a Shiny server (opens in default browser)
@@ -113,7 +113,7 @@
 #' }
 docklet_create <- function(name = random_name(),
                            size = getOption("do_size", "s-1vcpu-2gb"),
-                           region = getOption("do_region", "sfo1"),
+                           region = getOption("do_region", "sfo2"),
                            ssh_keys = getOption("do_ssh_keys", NULL),
                            backups = getOption("do_backups", NULL),
                            ipv6 = getOption("do_ipv6", NULL),
@@ -152,10 +152,10 @@ docklet_images <- function(droplet, all = TRUE, ssh_user = "root") {
 
 #' @export
 #' @rdname docklet_create
-docklet_pull <- function(droplet, repo, ssh_user = "root", keyfile = NULL, 
+docklet_pull <- function(droplet, repo, ssh_user = "root", keyfile = NULL,
   ssh_passwd = NULL, verbose = FALSE) {
 
-  docklet_docker(droplet, "pull", repo, ssh_user = ssh_user, 
+  docklet_docker(droplet, "pull", repo, ssh_user = ssh_user,
     keyfile = keyfile, ssh_passwd = ssh_passwd, verbose = verbose)
 }
 
@@ -169,8 +169,8 @@ docklet_run <- function(droplet, ..., rm = FALSE, name = NULL,
       if (rm) " --rm",
       if (!is.null(name)) paste0(" --name=", name),
       ...
-    ), 
-    ssh_user = ssh_user, keyfile = keyfile, ssh_passwd = ssh_passwd, 
+    ),
+    ssh_user = ssh_user, keyfile = keyfile, ssh_passwd = ssh_passwd,
     verbose = verbose
   )
 }
@@ -198,7 +198,7 @@ docklet_docker <- function(droplet, cmd, args = NULL, docker_args = NULL,
   droplet_ssh(
     droplet,
     user = ssh_user, keyfile = keyfile, ssh_passwd = ssh_passwd,
-    paste(c("docker", docker_args, cmd, args), collapse = " "), 
+    paste(c("docker", docker_args, cmd, args), collapse = " "),
     verbose = verbose)
 }
 
@@ -214,7 +214,7 @@ docklet_rstudio <- function(droplet, user, password,
   if (password == "rstudio") stop("supply a 'password' other than 'rstudio'")
   droplet <- as.droplet(droplet)
 
-  docklet_pull(droplet, img, ssh_user, keyfile = keyfile, 
+  docklet_pull(droplet, img, ssh_user, keyfile = keyfile,
     ssh_passwd = ssh_passwd, verbose = verbose)
   docklet_run(droplet,
     " -d",
@@ -227,7 +227,7 @@ docklet_rstudio <- function(droplet, user, password,
     img,
     ifelse(add_users, ' bash -c "add-students && supervisord" ', ' '),
     ssh_user = ssh_user,
-    keyfile = keyfile, 
+    keyfile = keyfile,
     ssh_passwd = ssh_passwd
   )
 
@@ -242,8 +242,8 @@ docklet_rstudio <- function(droplet, user, password,
 
 #' @export
 #' @rdname docklet_create
-docklet_rstudio_addusers <- function(droplet, user, password, 
-  img = 'rocker/rstudio', port = '8787', ssh_user = "root", keyfile = NULL, 
+docklet_rstudio_addusers <- function(droplet, user, password,
+  img = 'rocker/rstudio', port = '8787', ssh_user = "root", keyfile = NULL,
   ssh_passwd = NULL, verbose = FALSE) {
 
   check_for_a_pkg("ssh")
@@ -253,7 +253,7 @@ docklet_rstudio_addusers <- function(droplet, user, password,
   droplet <- as.droplet(droplet)
 
   # check if rstudio container already running, shut down if up
-  cons <- docklet_ps_data(droplet, ssh_user = ssh_user, 
+  cons <- docklet_ps_data(droplet, ssh_user = ssh_user,
     keyfile = keyfile, ssh_passwd = ssh_passwd, verbose = verbose)
   id <- cons[ grep("rocker/rstudio:latest", cons$image), "container.id" ]
   if (length(id) > 0) {

--- a/R/docklets_create.R
+++ b/R/docklets_create.R
@@ -16,7 +16,7 @@
 #' }
 docklets_create <- function(names = NULL,
                            size = getOption("do_size", "s-1vcpu-2gb"),
-                           region = getOption("do_region", "sfo1"),
+                           region = getOption("do_region", "sfo2"),
                            ssh_keys = getOption("do_ssh_keys", NULL),
                            backups = getOption("do_backups", NULL),
                            ipv6 = getOption("do_ipv6", NULL),

--- a/R/droplet-actions.R
+++ b/R/droplet-actions.R
@@ -19,7 +19,7 @@
 #'   list. Default: ubuntu-18-04-x64
 #' @param region (character) The unique slug identifier for the region that you
 #'   wish to deploy in. See \code{\link{regions}()} for a complete list.
-#'   Default: sfo1
+#'   Default: sfo2
 #' @param ssh_keys (character) A character vector of key names, an integer
 #'   vector of key ids, or NULL, to use all keys in your account. Accounts
 #'   with the corresponding private key will be able to log in to the droplet.
@@ -73,7 +73,7 @@
 #'
 #' # set name, size, image, and region
 #' droplet_create(name="newdrop", size = '512mb', image = 'ubuntu-14-04-x64',
-#'   region = 'sfo1')
+#'   region = 'sfo2')
 #'
 #' # use an ssh key
 #' droplet_create(ssh_keys=89103)
@@ -85,7 +85,7 @@
 droplet_create <- function(name = random_name(),
                         size = getOption("do_size", "s-1vcpu-1gb"),
                         image = getOption("do_image", "ubuntu-18-04-x64"),
-                        region = getOption("do_region", "sfo1"),
+                        region = getOption("do_region", "sfo2"),
                         ssh_keys = getOption("do_ssh_keys", NULL),
                         backups = getOption("do_backups", NULL),
                         ipv6 = getOption("do_ipv6", NULL),

--- a/R/droplets_create.R
+++ b/R/droplets_create.R
@@ -17,7 +17,7 @@
 #' after it's in waiting process (the string of ...), the droplet creation
 #' will continue.
 #' @template dropid
-#' 
+#'
 #' @return Two or more droplet objects
 #'
 #' @examples \dontrun{
@@ -35,7 +35,7 @@
 droplets_create <- function(names = NULL,
                            size = getOption("do_size", "s-1vcpu-1gb"),
                            image = getOption("do_image", "ubuntu-18-04-x64"),
-                           region = getOption("do_region", "sfo1"),
+                           region = getOption("do_region", "sfo2"),
                            ssh_keys = getOption("do_ssh_keys", NULL),
                            backups = getOption("do_backups", NULL),
                            ipv6 = getOption("do_ipv6", NULL),

--- a/man/docklet_create.Rd
+++ b/man/docklet_create.Rd
@@ -16,7 +16,7 @@
 \title{Docklets: docker on droplets.}
 \usage{
 docklet_create(name = random_name(), size = getOption("do_size",
-  "s-1vcpu-2gb"), region = getOption("do_region", "sfo1"),
+  "s-1vcpu-2gb"), region = getOption("do_region", "sfo2"),
   ssh_keys = getOption("do_ssh_keys", NULL),
   backups = getOption("do_backups", NULL), ipv6 = getOption("do_ipv6",
   NULL), private_networking = getOption("do_private_networking", NULL),
@@ -68,7 +68,7 @@ a complete list. Default: s-1vcpu-2gb}
 
 \item{region}{(character) The unique slug identifier for the region that you
 wish to deploy in. See \code{\link{regions}()} for a complete list.
-Default: sfo1}
+Default: sfo2}
 
 \item{ssh_keys}{(character) A character vector of key names, an integer
 vector of key ids, or NULL, to use all keys in your account. Accounts
@@ -223,7 +223,7 @@ d \%>\% droplet_delete()
 ## following pattern user1/user1 ... through 100
 d <- docklet_create()
 d <- droplet(d$id)
-d \%>\% docklet_rstudio(user = "foo", password = "bar") \%>\% 
+d \%>\% docklet_rstudio(user = "foo", password = "bar") \%>\%
  docklet_rstudio_addusers(user = "foo", password = "bar")
 
 # Spin up a Shiny server (opens in default browser)

--- a/man/docklets_create.Rd
+++ b/man/docklets_create.Rd
@@ -5,7 +5,7 @@
 \title{Docklets: docker on droplets - create many docklets}
 \usage{
 docklets_create(names = NULL, size = getOption("do_size",
-  "s-1vcpu-2gb"), region = getOption("do_region", "sfo1"),
+  "s-1vcpu-2gb"), region = getOption("do_region", "sfo2"),
   ssh_keys = getOption("do_ssh_keys", NULL),
   backups = getOption("do_backups", NULL), ipv6 = getOption("do_ipv6",
   NULL), private_networking = getOption("do_private_networking", NULL),
@@ -24,7 +24,7 @@ a complete list. Default: s-1vcpu-1gb, the smallest}
 
 \item{region}{(character) The unique slug identifier for the region that you
 wish to deploy in. See \code{\link{regions}()} for a complete list.
-Default: sfo1}
+Default: sfo2}
 
 \item{ssh_keys}{(character) A character vector of key names, an integer
 vector of key ids, or NULL, to use all keys in your account. Accounts

--- a/man/droplet_create.Rd
+++ b/man/droplet_create.Rd
@@ -6,7 +6,7 @@
 \usage{
 droplet_create(name = random_name(), size = getOption("do_size",
   "s-1vcpu-1gb"), image = getOption("do_image", "ubuntu-18-04-x64"),
-  region = getOption("do_region", "sfo1"),
+  region = getOption("do_region", "sfo2"),
   ssh_keys = getOption("do_ssh_keys", NULL),
   backups = getOption("do_backups", NULL), ipv6 = getOption("do_ipv6",
   NULL), private_networking = getOption("do_private_networking", NULL),
@@ -31,7 +31,7 @@ list. Default: ubuntu-18-04-x64}
 
 \item{region}{(character) The unique slug identifier for the region that you
 wish to deploy in. See \code{\link{regions}()} for a complete list.
-Default: sfo1}
+Default: sfo2}
 
 \item{ssh_keys}{(character) A character vector of key names, an integer
 vector of key ids, or NULL, to use all keys in your account. Accounts
@@ -108,7 +108,7 @@ droplet_create('droppinit')
 
 # set name, size, image, and region
 droplet_create(name="newdrop", size = '512mb', image = 'ubuntu-14-04-x64',
-  region = 'sfo1')
+  region = 'sfo2')
 
 # use an ssh key
 droplet_create(ssh_keys=89103)

--- a/man/droplets_create.Rd
+++ b/man/droplets_create.Rd
@@ -6,7 +6,7 @@
 \usage{
 droplets_create(names = NULL, size = getOption("do_size",
   "s-1vcpu-1gb"), image = getOption("do_image", "ubuntu-18-04-x64"),
-  region = getOption("do_region", "sfo1"),
+  region = getOption("do_region", "sfo2"),
   ssh_keys = getOption("do_ssh_keys", NULL),
   backups = getOption("do_backups", NULL), ipv6 = getOption("do_ipv6",
   NULL), private_networking = getOption("do_private_networking", NULL),
@@ -31,7 +31,7 @@ list. Default: ubuntu-18-04-x64}
 
 \item{region}{(character) The unique slug identifier for the region that you
 wish to deploy in. See \code{\link{regions}()} for a complete list.
-Default: sfo1}
+Default: sfo2}
 
 \item{ssh_keys}{(character) A character vector of key names, an integer
 vector of key ids, or NULL, to use all keys in your account. Accounts

--- a/vignettes/analogsea.Rmd
+++ b/vignettes/analogsea.Rmd
@@ -472,7 +472,7 @@ You can transfer an image to another region
 
 
 ```r
-image(img$id) %>% image_transfer(region = "sfo1")
+image(img$id) %>% image_transfer(region = "sfo2")
 ```
 
 ## Domains


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Hi Scott, 
according to the [DO Droplet Availability Plan](https://www.digitalocean.com/docs/platform/availability-matrix/#droplet-plan-availability) the region 'SFO1' has 'Limited capacity' (since March 2019) and is restricted to users with existing resources only.  So to spin up a new droplet without having an existing droplet in 'sfo1' gives an error:

```r
droplet_create()
Using default ssh keys: dada2-tut
Error: Region is not available
```
This PR changed the default region from 'sfo1' to 'sfo2'.
