### PR TITLE
Move aws.s3 to Suggests due to it being orphaned

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,11 +28,11 @@ Imports:
     httr (>= 1.2.0),
     jsonlite (>= 1.1),
     magrittr,
-    yaml,
-    aws.s3
+    yaml
 Suggests:
     roxygen2 (>= 7.0.2),
     testthat,
     knitr,
-    ssh (>= 0.6)
+    ssh (>= 0.6),
+    aws.s3
 RoxygenNote: 7.0.2

--- a/R/space_create.R
+++ b/R/space_create.R
@@ -16,6 +16,8 @@ space_create <- function(name,
                          spaces_key = NULL,
                          spaces_secret = NULL,
                          ...) {
+  check_for_a_pkg("aws.s3")
+
   spaces_region <- check_space_region(spaces_region)
   spaces_key <- check_space_access(spaces_key)
   spaces_secret <- check_space_secret(spaces_secret)

--- a/R/spaces.R
+++ b/R/spaces.R
@@ -5,7 +5,9 @@ spaces_base <- "digitaloceanspaces.com"
 #' DigitalOcean provides support for storing files (Objects) in Spaces. This is
 #' useful for storing related files for fast access, sharing, etc. See
 #' https://developers.digitalocean.com/documentation/spaces/
-#' for more information.
+#' for more information. The `aws.s3` package is required to use `analogsea`'s
+#' Spaces functionality so be sure to install it with
+#' `install.packages("aws.s3")` prior to continuing.
 #'
 #' In order to get started using the Spaces API, you'll need to generate a new
 #' "Spaces access key" in the API section of your DigitalOcean control panel and
@@ -86,6 +88,8 @@ check_space_secret <- function(spaces_secret) {
 spaces <- function(spaces_region = NULL,
                    spaces_key = NULL,
                    spaces_secret = NULL, ...) {
+  check_for_a_pkg("aws.s3")
+
   res <- spaces_GET(spaces_region = spaces_region,
                     spaces_key = spaces_key,
                     spaces_secret = spaces_secret,

--- a/man/spaces_info.Rd
+++ b/man/spaces_info.Rd
@@ -12,7 +12,9 @@
 DigitalOcean provides support for storing files (Objects) in Spaces. This is
 useful for storing related files for fast access, sharing, etc. See
 https://developers.digitalocean.com/documentation/spaces/
-for more information.
+for more information. The \code{aws.s3} package is required to use \code{analogsea}'s
+Spaces functionality so be sure to install it with
+\code{install.packages("aws.s3")} prior to continuing.
 }
 \details{
 In order to get started using the Spaces API, you'll need to generate a new


### PR DESCRIPTION
As discussed in #188,

- Moves aws.s3 to Suggests due to it being orphaned.
- Puts `check_for_a_pkg` checks for aws.s3 in spaces() and space_create() as those are our two exported functions.
- Added a blurb in ?spaces_info about having to install aws.s3 first.

Closes #188