### PR TITLE
fix for https://github.com/sckott/analogsea/issues/193

### DIFF
--- a/R/droplet_execute.R
+++ b/R/droplet_execute.R
@@ -42,11 +42,11 @@ droplet_execute <- function(droplet, code, verbose=TRUE) {
   droplet_ssh(droplet, "Rscript --save remote.R")
 
   mssg(verbose, "Downloading results...")
-  tmp <- tempfile()
+  tmp <- tempdir()
   droplet_download(droplet, ".RData", tmp)
 
   e <- new.env(parent = emptyenv())
-  load(tmp, envir = e)
+  load(file.path(tmp, ".RData"), envir = e)
 
   as.list(e)
 }


### PR DESCRIPTION
This is a proposed fix for https://github.com/sckott/analogsea/issues/193

## Description

It seems that `ssh::scp_download()` expects a directory to download files into, while `droplet_execute()` passes a temporary file. I made some changes so `.RData` is downloaded to a temporary directory and loaded from there.

## Related Issue

https://github.com/sckott/analogsea/issues/193
