### PR TITLE
Using public IP address

### DIFF
--- a/R/droplet-ssh.R
+++ b/R/droplet-ssh.R
@@ -115,7 +115,7 @@ droplet_ip <- function(x) {
   if (!any(public_ip)) {
     ip <- v4[[1]]$ip_address
   } else {
-    ip <- ips$ip_address[public_ip] [[1]]
+    ip <- ips$ip_address[public_ip][[1]]
   }
   ip
 }

--- a/R/droplet-ssh.R
+++ b/R/droplet-ssh.R
@@ -79,25 +79,26 @@ droplet_ssh <- function(droplet, ..., user = "root", keyfile = NULL, ssh_passwd 
 #' @export
 #' @rdname droplet_ssh
 droplet_upload <- function(droplet, local, remote, user = "root", keyfile = NULL,
-  ssh_passwd = NULL, verbose = FALSE) {
-
+                           ssh_passwd = NULL, verbose = FALSE) {
   check_for_a_pkg("ssh")
   droplet <- as.droplet(droplet)
   do_scp(droplet, local, remote, user,
     keyfile = keyfile, ssh_passwd = ssh_passwd,
-    verbose = verbose)
+    verbose = verbose
+  )
 }
 
 
 #' @export
 #' @rdname droplet_ssh
 droplet_download <- function(droplet, remote, local, user = "root",
-  keyfile = NULL, ssh_passwd = NULL, verbose = FALSE, overwrite = FALSE) {
-
+                             keyfile = NULL, ssh_passwd = NULL, verbose = FALSE, overwrite = FALSE) {
   check_for_a_pkg("ssh")
   droplet <- as.droplet(droplet)
-  do_scp(droplet, local, remote, user, scp = "download",
-    keyfile, ssh_passwd, verbose = verbose)
+  do_scp(droplet, local, remote, user,
+    scp = "download",
+    keyfile, ssh_passwd, verbose = verbose
+  )
 }
 
 
@@ -106,21 +107,22 @@ droplet_ip <- function(x) {
   v4 <- x$network$v4
   if (length(v4) == 0) {
     stop("No network interface registered for this droplet\n  Try refreshing like: droplet(d$id)",
-      call. = FALSE)
+      call. = FALSE
+    )
   }
-  ips = do.call("rbind", lapply(v4, as.data.frame))
-  public_ip = ips$type == "public"
+  ips <- do.call("rbind", lapply(v4, as.data.frame))
+  public_ip <- ips$type == "public"
   if (!any(public_ip)) {
-    ip =v4[[1]]$ip_address
+    ip <- v4[[1]]$ip_address
   } else {
-    ip = ips$ip_address[ public_ip] [[1]]
+    ip <- ips$ip_address[public_ip] [[1]]
   }
   ip
 }
 
 droplet_ip_safe <- function(x) {
   res <- tryCatch(droplet_ip(x), error = function(e) e)
-  if (inherits(res, "simpleError")) 'droplet likely not up yet' else res
+  if (inherits(res, "simpleError")) "droplet likely not up yet" else res
 }
 
 do_ssh <- function(droplet, cmd, user, keyfile = NULL, ssh_passwd = NULL, verbose = FALSE) {
@@ -128,7 +130,7 @@ do_ssh <- function(droplet, cmd, user, keyfile = NULL, ssh_passwd = NULL, verbos
   user_ip <- sprintf("%s@%s", user, droplet_ip_safe(droplet))
   if (user_ip %in% ls(envir = analogsea_sessions)) {
     session <- get(user_ip, envir = analogsea_sessions)
-    if (!ssh::ssh_info(session=session)$connected) {
+    if (!ssh::ssh_info(session = session)$connected) {
       session <- if (is.null(ssh_passwd)) {
         ssh::ssh_connect(user_ip, keyfile)
       } else {
@@ -153,8 +155,7 @@ do_ssh <- function(droplet, cmd, user, keyfile = NULL, ssh_passwd = NULL, verbos
 }
 
 do_scp <- function(droplet, local, remote, user,
-  scp = "upload", keyfile = NULL, ssh_passwd = NULL, verbose = FALSE) {
-
+                   scp = "upload", keyfile = NULL, ssh_passwd = NULL, verbose = FALSE) {
   user_ip <- sprintf("%s@%s", user, droplet_ip_safe(droplet))
   if (user_ip %in% ls(envir = analogsea_sessions)) {
     session <- get(user_ip, envir = analogsea_sessions)
@@ -166,9 +167,17 @@ do_scp <- function(droplet, local, remote, user,
     }
     assign(user_ip, session, envir = analogsea_sessions)
   }
-  if (scp == "upload") cat(ssh::scp_upload(session = session,
-    files = local, to = remote, verbose = TRUE), sep = "\n")
-  if (scp == "download") cat(ssh::scp_download(session = session,
-    files = remote, to = local, verbose = TRUE), sep = "\n")
+  if (scp == "upload") {
+    cat(ssh::scp_upload(
+      session = session,
+      files = local, to = remote, verbose = TRUE
+    ), sep = "\n")
+  }
+  if (scp == "download") {
+    cat(ssh::scp_download(
+      session = session,
+      files = remote, to = local, verbose = TRUE
+    ), sep = "\n")
+  }
   invisible(droplet)
 }

--- a/R/droplet-ssh.R
+++ b/R/droplet-ssh.R
@@ -108,8 +108,14 @@ droplet_ip <- function(x) {
     stop("No network interface registered for this droplet\n  Try refreshing like: droplet(d$id)",
       call. = FALSE)
   }
-
-  v4[[1]]$ip_address
+  ips = do.call("rbind", lapply(v4, as.data.frame))
+  public_ip = ips$type == "public"
+  if (!any(public_ip)) {
+    ip =v4[[1]]$ip_address
+  } else {
+    ip = ips$ip_address[ public_ip] [[1]]
+  }
+  ip
 }
 
 droplet_ip_safe <- function(x) {


### PR DESCRIPTION
Ensuring the IP address is the public address.

## Description
I had run into issues with private IP addresses that were going through a different netmask and gateway, but I wanted to use the public IP, which resulted in issues such as:
```
Error: libssh failure at 'connect': Timeout connecting to 10.120.0.2
```
which is likely due to my mesh network configuration.

I don't know how to make a test to ensure that the `droplet` has a series of networks.  Here is one I created (and have since destroyed):


## Using current analogsea

    remotes::install_github("sckott/analogsea")
    #> Using github PAT from envvar GITHUB_PAT
    #> Downloading GitHub repo sckott/analogsea@HEAD
    #> 
    #>      checking for file ‘/private/var/folders/1s/wrtqcpxn685_zk570bnx9_rr0000gr/T/RtmpM13MgO/remotesa6fa3e643062/sckott-analogsea-be86c05/DESCRIPTION’ ...  ✓  checking for file ‘/private/var/folders/1s/wrtqcpxn685_zk570bnx9_rr0000gr/T/RtmpM13MgO/remotesa6fa3e643062/sckott-analogsea-be86c05/DESCRIPTION’
    #>   ─  preparing ‘analogsea’:
    #>   ✓  checking DESCRIPTION meta-information
    #>   ─  checking for LF line-endings in source and make files and shell scripts
    #>   ─  checking for empty or unneeded directories
    #>   ─  building ‘analogsea_0.8.1.92.tar.gz’
    #>      
    #> 
    #> Installing package into '/Users/johnmuschelli/Library/R/4.0/library'
    #> (as 'lib' is unspecified)
    library(analogsea)
    #> 
    #> Attaching package: 'analogsea'
    #> The following object is masked from 'package:graphics':
    #> 
    #>     image
    droplet = structure(list(id = 210324177L, name = "TougherAviation", memory = 1024L, 
                             vcpus = 1L, disk = 25L, locked = FALSE, status = "active", 
                             kernel = NULL, created_at = "2020-10-02T15:56:50Z", features = list(
                               "private_networking"), backup_ids = list(), next_backup_window = NULL, 
                             snapshot_ids = list(), image = list(id = 69439389L, name = "18.04 (LTS) x64", 
                                                                 distribution = "Ubuntu", slug = "ubuntu-18-04-x64", public = TRUE, 
                                                                 regions = list("nyc3", "nyc1", "sfo1", "nyc2", "ams2", 
                                                                                "sgp1", "lon1", "ams3", "fra1", "tor1", "sfo2", "blr1", 
                                                                                "sfo3"), created_at = "2020-09-02T19:36:10Z", min_disk_size = 15L, 
                                                                 type = "base", size_gigabytes = 2.36, description = "Ubuntu 18.04 x86 image", 
                                                                 tags = list(), status = "available"), volume_ids = list(), 
                             size = list(slug = "s-1vcpu-1gb", memory = 1024L, vcpus = 1L, 
                                         disk = 25L, transfer = 1, price_monthly = 5, price_hourly = 0.00744, 
                                         regions = list("ams2", "ams3", "blr1", "fra1", "lon1", 
                                                        "nyc1", "nyc2", "nyc3", "sfo1", "sfo2", "sfo3", "sgp1", 
                                                        "tor1"), available = TRUE), size_slug = "s-1vcpu-1gb", 
                             networks = list(v4 = list(list(ip_address = "10.120.0.2", 
                                                            netmask = "255.255.240.0", gateway = "<nil>", type = "private"), 
                                                       list(ip_address = "64.225.124.41", netmask = "255.255.240.0", 
                                                            gateway = "64.225.112.1", type = "public")), v6 = list()), 
                             region = list(name = "San Francisco 2", slug = "sfo2", features = list(
                               "private_networking", "backups", "ipv6", "metadata", 
                               "install_agent", "storage", "image_transfer"), available = TRUE, 
                               sizes = list("s-1vcpu-1gb", "512mb", "s-1vcpu-2gb", "1gb", 
                                            "s-3vcpu-1gb", "s-2vcpu-2gb", "s-1vcpu-3gb", "s-2vcpu-4gb", 
                                            "2gb", "s-4vcpu-8gb", "m-1vcpu-8gb", "c-2", "4gb", 
                                            "c2-2vcpu-4gb", "g-2vcpu-8gb", "gd-2vcpu-8gb", "m-16gb", 
                                            "s-8vcpu-16gb", "s-6vcpu-16gb", "c-4", "8gb", "c2-4vpcu-8gb", 
                                            "m-2vcpu-16gb", "m3-2vcpu-16gb", "g-4vcpu-16gb", 
                                            "gd-4vcpu-16gb", "m6-2vcpu-16gb", "m-32gb", "s-8vcpu-32gb", 
                                            "c-8", "16gb", "c2-8vpcu-16gb", "m-4vcpu-32gb", "m3-4vcpu-32gb", 
                                            "g-8vcpu-32gb", "s-12vcpu-48gb", "gd-8vcpu-32gb", 
                                            "m6-4vcpu-32gb", "m-64gb", "s-16vcpu-64gb", "c-16", 
                                            "32gb", "c2-16vcpu-32gb", "m-8vcpu-64gb", "m3-8vcpu-64gb", 
                                            "g-16vcpu-64gb", "s-20vcpu-96gb", "48gb", "gd-16vcpu-64gb", 
                                            "m6-8vcpu-64gb", "m-128gb", "s-24vcpu-128gb", "c-32", 
                                            "64gb", "c2-32vpcu-64gb", "m-16vcpu-128gb", "m3-16vcpu-128gb", 
                                            "g-32vcpu-128gb", "s-32vcpu-192gb", "gd-32vcpu-128gb", 
                                            "m-224gb", "m6-16vcpu-128gb", "g-40vcpu-160gb", "gd-40vcpu-160gb")), 
                             tags = list(), vpc_uuid = "5243aa8a-2d90-46d9-9be8-686db7a6a9bb"), class = "droplet")
    droplet
    #> <droplet>TougherAviation (210324177)
    #>   IP:        10.120.0.2
    #>   Status:    active
    #>   Region:    San Francisco 2
    #>   Image:     18.04 (LTS) x64
    #>   Size:      s-1vcpu-1gb
    #>   Volumes:
    analogsea:::droplet_ip(droplet)
    #> [1] "10.120.0.2"

<sup>Created on 2020-10-02 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

    sessioninfo::session_info()
    #> ─ Session info ───────────────────────────────────────────────────────────────
    #>  setting  value                       
    #>  version  R version 4.0.2 (2020-06-22)
    #>  os       macOS Catalina 10.15.6      
    #>  system   x86_64, darwin17.0          
    #>  ui       X11                         
    #>  language (EN)                        
    #>  collate  en_US.UTF-8                 
    #>  ctype    en_US.UTF-8                 
    #>  tz       America/New_York            
    #>  date     2020-10-02                  
    #> 
    #> ─ Packages ───────────────────────────────────────────────────────────────────
    #>  package     * version    date       lib source                           
    #>  analogsea   * 0.8.1.92   2020-10-02 [1] Github (sckott/analogsea@be86c05)
    #>  assertthat    0.2.1      2019-03-21 [2] CRAN (R 4.0.0)                   
    #>  backports     1.1.10     2020-09-15 [1] CRAN (R 4.0.2)                   
    #>  callr         3.4.4      2020-09-07 [1] CRAN (R 4.0.2)                   
    #>  cli           2.0.2      2020-02-28 [2] CRAN (R 4.0.0)                   
    #>  crayon        1.3.4      2017-09-16 [2] CRAN (R 4.0.0)                   
    #>  curl          4.3        2019-12-02 [2] CRAN (R 4.0.0)                   
    #>  digest        0.6.25     2020-02-23 [2] CRAN (R 4.0.0)                   
    #>  ellipsis      0.3.1      2020-05-15 [2] CRAN (R 4.0.0)                   
    #>  evaluate      0.14       2019-05-28 [2] CRAN (R 4.0.0)                   
    #>  fansi         0.4.1      2020-01-08 [2] CRAN (R 4.0.0)                   
    #>  fs            1.5.0      2020-07-31 [2] CRAN (R 4.0.2)                   
    #>  glue          1.4.2      2020-08-27 [1] CRAN (R 4.0.2)                   
    #>  highr         0.8        2019-03-20 [2] CRAN (R 4.0.0)                   
    #>  htmltools     0.5.0      2020-06-16 [2] CRAN (R 4.0.0)                   
    #>  httr          1.4.2      2020-07-20 [2] CRAN (R 4.0.2)                   
    #>  jsonlite      1.7.1      2020-09-07 [1] CRAN (R 4.0.2)                   
    #>  knitr         1.30       2020-09-22 [1] CRAN (R 4.0.2)                   
    #>  lifecycle     0.2.0      2020-03-06 [2] CRAN (R 4.0.0)                   
    #>  magrittr      1.5        2014-11-22 [2] CRAN (R 4.0.0)                   
    #>  pillar        1.4.6      2020-07-10 [2] CRAN (R 4.0.2)                   
    #>  pkgbuild      1.1.0      2020-07-13 [2] CRAN (R 4.0.2)                   
    #>  pkgconfig     2.0.3      2019-09-22 [2] CRAN (R 4.0.0)                   
    #>  prettyunits   1.1.1      2020-01-24 [2] CRAN (R 4.0.0)                   
    #>  processx      3.4.4      2020-09-03 [1] CRAN (R 4.0.2)                   
    #>  ps            1.3.4      2020-08-11 [2] CRAN (R 4.0.2)                   
    #>  purrr         0.3.4      2020-04-17 [2] CRAN (R 4.0.0)                   
    #>  R6            2.4.1      2019-11-12 [2] CRAN (R 4.0.0)                   
    #>  remotes       2.2.0      2020-07-21 [2] CRAN (R 4.0.2)                   
    #>  reprex        0.3.0.9001 2020-09-30 [1] Github (tidyverse/reprex@d3fc4b8)
    #>  rlang         0.4.7.9000 2020-09-09 [1] Github (r-lib/rlang@60c0151)     
    #>  rmarkdown     2.3        2020-06-18 [2] CRAN (R 4.0.0)                   
    #>  rprojroot     1.3-2      2018-01-03 [2] CRAN (R 4.0.0)                   
    #>  rstudioapi    0.11       2020-02-07 [2] CRAN (R 4.0.0)                   
    #>  sessioninfo   1.1.1      2018-11-05 [2] CRAN (R 4.0.0)                   
    #>  stringi       1.5.3      2020-09-09 [1] CRAN (R 4.0.2)                   
    #>  stringr       1.4.0      2019-02-10 [2] CRAN (R 4.0.0)                   
    #>  styler        1.3.2      2020-02-23 [2] CRAN (R 4.0.0)                   
    #>  tibble        3.0.3      2020-07-10 [2] CRAN (R 4.0.2)                   
    #>  vctrs         0.3.4      2020-08-29 [1] CRAN (R 4.0.2)                   
    #>  withr         2.3.0      2020-09-22 [1] CRAN (R 4.0.2)                   
    #>  xfun          0.18       2020-09-29 [1] CRAN (R 4.0.2)                   
    #>  yaml          2.2.1      2020-02-01 [2] CRAN (R 4.0.0)                   
    #> 
    #> [1] /Users/johnmuschelli/Library/R/4.0/library
    #> [2] /Library/Frameworks/R.framework/Versions/4.0/Resources/library

</details>


##  Using this PR


    remove.packages("analogsea")
    #> Removing package from '/Users/johnmuschelli/Library/R/4.0/library'
    #> (as 'lib' is unspecified)
    remotes::install_github("muschellij2/analogsea@public_ip")
    #> Using github PAT from envvar GITHUB_PAT
    #> Downloading GitHub repo muschellij2/analogsea@public_ip
    #> 
    #>      checking for file ‘/private/var/folders/1s/wrtqcpxn685_zk570bnx9_rr0000gr/T/RtmpAuqvFq/remotesa6ae40dcc1da/muschellij2-analogsea-6ba14c2/DESCRIPTION’ ...  ✓  checking for file ‘/private/var/folders/1s/wrtqcpxn685_zk570bnx9_rr0000gr/T/RtmpAuqvFq/remotesa6ae40dcc1da/muschellij2-analogsea-6ba14c2/DESCRIPTION’
    #>   ─  preparing ‘analogsea’:
    #>      checking DESCRIPTION meta-information ...  ✓  checking DESCRIPTION meta-information
    #>   ─  checking for LF line-endings in source and make files and shell scripts
    #>   ─  checking for empty or unneeded directories
    #>   ─  building ‘analogsea_0.8.1.92.tar.gz’
    #>      
    #> 
    #> Installing package into '/Users/johnmuschelli/Library/R/4.0/library'
    #> (as 'lib' is unspecified)

    droplet = structure(list(id = 210324177L, name = "TougherAviation", memory = 1024L, 
                             vcpus = 1L, disk = 25L, locked = FALSE, status = "active", 
                             kernel = NULL, created_at = "2020-10-02T15:56:50Z", features = list(
                               "private_networking"), backup_ids = list(), next_backup_window = NULL, 
                             snapshot_ids = list(), image = list(id = 69439389L, name = "18.04 (LTS) x64", 
                                                                 distribution = "Ubuntu", slug = "ubuntu-18-04-x64", public = TRUE, 
                                                                 regions = list("nyc3", "nyc1", "sfo1", "nyc2", "ams2", 
                                                                                "sgp1", "lon1", "ams3", "fra1", "tor1", "sfo2", "blr1", 
                                                                                "sfo3"), created_at = "2020-09-02T19:36:10Z", min_disk_size = 15L, 
                                                                 type = "base", size_gigabytes = 2.36, description = "Ubuntu 18.04 x86 image", 
                                                                 tags = list(), status = "available"), volume_ids = list(), 
                             size = list(slug = "s-1vcpu-1gb", memory = 1024L, vcpus = 1L, 
                                         disk = 25L, transfer = 1, price_monthly = 5, price_hourly = 0.00744, 
                                         regions = list("ams2", "ams3", "blr1", "fra1", "lon1", 
                                                        "nyc1", "nyc2", "nyc3", "sfo1", "sfo2", "sfo3", "sgp1", 
                                                        "tor1"), available = TRUE), size_slug = "s-1vcpu-1gb", 
                             networks = list(v4 = list(list(ip_address = "10.120.0.2", 
                                                            netmask = "255.255.240.0", gateway = "<nil>", type = "private"), 
                                                       list(ip_address = "64.225.124.41", netmask = "255.255.240.0", 
                                                            gateway = "64.225.112.1", type = "public")), v6 = list()), 
                             region = list(name = "San Francisco 2", slug = "sfo2", features = list(
                               "private_networking", "backups", "ipv6", "metadata", 
                               "install_agent", "storage", "image_transfer"), available = TRUE, 
                               sizes = list("s-1vcpu-1gb", "512mb", "s-1vcpu-2gb", "1gb", 
                                            "s-3vcpu-1gb", "s-2vcpu-2gb", "s-1vcpu-3gb", "s-2vcpu-4gb", 
                                            "2gb", "s-4vcpu-8gb", "m-1vcpu-8gb", "c-2", "4gb", 
                                            "c2-2vcpu-4gb", "g-2vcpu-8gb", "gd-2vcpu-8gb", "m-16gb", 
                                            "s-8vcpu-16gb", "s-6vcpu-16gb", "c-4", "8gb", "c2-4vpcu-8gb", 
                                            "m-2vcpu-16gb", "m3-2vcpu-16gb", "g-4vcpu-16gb", 
                                            "gd-4vcpu-16gb", "m6-2vcpu-16gb", "m-32gb", "s-8vcpu-32gb", 
                                            "c-8", "16gb", "c2-8vpcu-16gb", "m-4vcpu-32gb", "m3-4vcpu-32gb", 
                                            "g-8vcpu-32gb", "s-12vcpu-48gb", "gd-8vcpu-32gb", 
                                            "m6-4vcpu-32gb", "m-64gb", "s-16vcpu-64gb", "c-16", 
                                            "32gb", "c2-16vcpu-32gb", "m-8vcpu-64gb", "m3-8vcpu-64gb", 
                                            "g-16vcpu-64gb", "s-20vcpu-96gb", "48gb", "gd-16vcpu-64gb", 
                                            "m6-8vcpu-64gb", "m-128gb", "s-24vcpu-128gb", "c-32", 
                                            "64gb", "c2-32vpcu-64gb", "m-16vcpu-128gb", "m3-16vcpu-128gb", 
                                            "g-32vcpu-128gb", "s-32vcpu-192gb", "gd-32vcpu-128gb", 
                                            "m-224gb", "m6-16vcpu-128gb", "g-40vcpu-160gb", "gd-40vcpu-160gb")), 
                             tags = list(), vpc_uuid = "5243aa8a-2d90-46d9-9be8-686db7a6a9bb"), class = "droplet")
    library(analogsea)
    #> 
    #> Attaching package: 'analogsea'
    #> The following object is masked from 'package:graphics':
    #> 
    #>     image
    droplet
    #> <droplet>TougherAviation (210324177)
    #>   IP:        64.225.124.41
    #>   Status:    active
    #>   Region:    San Francisco 2
    #>   Image:     18.04 (LTS) x64
    #>   Size:      s-1vcpu-1gb
    #>   Volumes:
    analogsea:::droplet_ip(droplet)
    #> [1] "64.225.124.41"
    unloadNamespace("analogsea")
    remove.packages("analogsea")
    #> Removing package from '/Users/johnmuschelli/Library/R/4.0/library'
    #> (as 'lib' is unspecified)

<sup>Created on 2020-10-02 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>



