### PR TITLE
Use secure CRAN mirror

### DIFF
--- a/R/debian.R
+++ b/R/debian.R
@@ -61,7 +61,7 @@ debian_install_r <- function(droplet,
                            ssh_passwd = ssh_passwd,
                            verbose = verbose
                            ) %>%
-    droplet_ssh('echo "options(repos=c(\'https://cran.rstudio.com/\'))" > .Rprofile',
+    droplet_ssh('echo "options(repos=c(\'https://cloud.r-project.org/\'))" > .Rprofile',
                 user = user,
                 keyfile = keyfile,
                 ssh_passwd = ssh_passwd,

--- a/R/debian.R
+++ b/R/debian.R
@@ -61,7 +61,7 @@ debian_install_r <- function(droplet,
                            ssh_passwd = ssh_passwd,
                            verbose = verbose
                            ) %>%
-    droplet_ssh('echo "options(repos=c(\'http://cran.rstudio.com/\'))" > .Rprofile',
+    droplet_ssh('echo "options(repos=c(\'https://cran.rstudio.com/\'))" > .Rprofile',
                 user = user,
                 keyfile = keyfile,
                 ssh_passwd = ssh_passwd,


### PR DESCRIPTION
A simple one character PR to use the https CRAN mirror instead of the http
